### PR TITLE
fix: do not lowercase token addresses

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -1609,7 +1609,7 @@ export const defaultCoins: Array<Coin> = basicCoins.map((coin) => {
 
   for (const [chainId, token] of Object.entries(coin.chains)) {
     defaultCoin.chains[chainId] = {
-      address: token.address.toLowerCase(),
+      address: token.address,
       decimals: token.decimals,
       symbol: token.symbol ?? coin.key,
       chainId: parseInt(chainId), // Object.entries, Object.keys etc. only return keys as strings. Therefore, we have to parse them here


### PR DESCRIPTION
We cannot lowercase solana addresses - and we probably should not blindly lowercase EVM addresses. Lowercasing can still be used for token comparison.