### PR TITLE
fix: replace dead Pocket RPC

### DIFF
--- a/src/chains/supportedChains.ts
+++ b/src/chains/supportedChains.ts
@@ -132,8 +132,8 @@ export const supportedEVMChains: EVMChain[] = [
         decimals: 18,
       },
       rpcUrls: [
-        'https://rpc.gnosischain.com/',
         'https://rpc.gnosis.gateway.fm',
+        'https://rpc.gnosischain.com',
         'https://rpc.ankr.com/gnosis',
       ],
     },

--- a/src/chains/supportedChains.ts
+++ b/src/chains/supportedChains.ts
@@ -133,8 +133,8 @@ export const supportedEVMChains: EVMChain[] = [
       },
       rpcUrls: [
         'https://rpc.gnosischain.com/',
+        'https://rpc.gnosis.gateway.fm',
         'https://rpc.ankr.com/gnosis',
-        'https://xdai-rpc.gateway.pokt.network',
       ],
     },
   },


### PR DESCRIPTION
Since Pockets rebranding to Grove their public Gnosis RPC is dead. Instead of replacing it with a new Grove RPC I decided to use the RPC that the official documentation suggests: https://docs.gnosischain.com/tools/rpc/