### PR TITLE
fix(metis): set correct native token

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -1525,7 +1525,7 @@ export const basicCoins: BasicCoin[] = [
     chains: {
       [ChainId.CEL]: {
         // The CELO token is not a native token (0x000...).
-        // Instead it is this ERC20 token: https://explorer.celo.org/token/0x471EcE3750Da237f93B8E339c536989b8978a438
+        // Instead, it is this ERC20 token: https://explorer.celo.org/token/0x471EcE3750Da237f93B8E339c536989b8978a438
         address: '0x471ece3750da237f93b8e339c536989b8978a438',
         decimals: 18,
       },
@@ -1557,7 +1557,9 @@ export const basicCoins: BasicCoin[] = [
     verified: true,
     chains: {
       [ChainId.MAM]: {
-        address: '0x0000000000000000000000000000000000000000',
+        // The CELO token is not a native token (0x000...).
+        // Instead, it is this ERC20 token: https://andromeda-explorer.metis.io/address/0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000
+        address: '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
         decimals: 18,
       },
     },


### PR DESCRIPTION
Native on Metis is not AddressZero, instead it's this token. Tested on the backend already