### PR TITLE
fix: modified deprecated RPC for Polygon

### DIFF
--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -61,7 +61,7 @@ export const supportedEVMChains: EVMChain[] = [
       },
       rpcUrls: [
         'https://polygon-rpc.com/',
-        'https://rpc-mainnet.maticvigil.com/',
+        'https://polygon.llamarpc.com/',
       ],
     },
   },


### PR DESCRIPTION
The RPC https://rpc-mainnet.maticvigil.com/  has responded with "Our RPC is deprecated. Please use another provider." Added https://polygon.llamarpc.com/ instead.