### PR TITLE
fix: native metis token address

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -1251,7 +1251,7 @@ export const basicCoins: BasicCoin[] = [
     verified: true,
     chains: {
       [ChainId.MAM]: {
-        address: '0x0000000000000000000000000000000000000000',
+        address: '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
         decimals: 18,
       },
     },


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-8750
All the tools that support Metis use this native address, not 0x000