### PR TITLE
feat: support migration from Matic to Pol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.6.0](https://github.com/lifinance/data-types/compare/v5.1.0...v5.6.0) (2024-09-02)
+
+
+### Features
+
+* add gravity chain ([#59](https://github.com/lifinance/data-types/issues/59)) ([eedaef0](https://github.com/lifinance/data-types/commit/eedaef05b37f51b0568db3a4b83fa456b3ba6089))
+* add immutable-x chain ([#62](https://github.com/lifinance/data-types/issues/62)) ([d440f96](https://github.com/lifinance/data-types/commit/d440f96ff5cb7a00e110fb25f5d6cb51632cec23))
+* enable taiko ([#58](https://github.com/lifinance/data-types/issues/58)) ([86cf72e](https://github.com/lifinance/data-types/commit/86cf72e95a935ac9949cf5ab2d2f955df1be9fca))
+* support migration from Matic to Pol ([a82ca1e](https://github.com/lifinance/data-types/commit/a82ca1e9173255e5d8fc6a7eb73c3f669b26b8b5))
+
+
+### Bug Fixes
+
+* migrate wmatic ([1cd459a](https://github.com/lifinance/data-types/commit/1cd459a738bd1b1689d693bfa17fa49805c27c6d))
+* update the version ([#61](https://github.com/lifinance/data-types/issues/61)) ([8b8000d](https://github.com/lifinance/data-types/commit/8b8000d6df4d9d0afc15eae458e51873e716c48f))
+* wrong token name ([#60](https://github.com/lifinance/data-types/issues/60)) ([1ae332d](https://github.com/lifinance/data-types/commit/1ae332d9359457f65effe9fa4714e89daf44351f))
+
 ## [5.5.0](https://github.com/lifinance/data-types/compare/v5.1.0...v5.5.0) (2024-08-16)
 
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "^15.3.1"
+    "@lifi/types": "^15.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -45,8 +45,8 @@ export const supportedEVMChains: EVMChain[] = [
     key: ChainKey.POL,
     chainType: ChainType.EVM,
     name: 'Polygon',
-    coin: CoinKey.MATIC,
-    id: 137,
+    coin: CoinKey.POL,
+    id: ChainId.POL,
     mainnet: true,
     logoURI:
       'https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/polygon.svg',
@@ -59,8 +59,8 @@ export const supportedEVMChains: EVMChain[] = [
       blockExplorerUrls: ['https://polygonscan.com/'],
       chainName: 'Polygon Mainnet',
       nativeCurrency: {
-        name: 'MATIC',
-        symbol: 'MATIC',
+        name: 'Polygon Ecosystem Token',
+        symbol: 'POL',
         decimals: 18,
       },
       rpcUrls: [

--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -152,10 +152,6 @@ export const basicCoins: BasicCoin[] = [
         decimals: 18,
         name: 'Matic Token',
       },
-      [ChainId.POL]: {
-        address: '0x0000000000000000000000000000000000000000',
-        decimals: 18,
-      },
       [ChainId.DAI]: {
         address: '0x7122d7661c4564b7c6cd4878b06766489a6028a2',
         decimals: 18,
@@ -165,6 +161,40 @@ export const basicCoins: BasicCoin[] = [
       [ChainId.VEL]: {
         address: '0x6ab0b8c1a35f9f4ce107ccbd05049cb1dbd99ec5',
         decimals: 18,
+      },
+    },
+  },
+  // > WMATIC
+  {
+    key: 'WMATIC' as CoinKey,
+    name: CoinKey.POL,
+    logoURI:
+      'https://static.debank.com/image/matic_token/logo_url/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/f6e604ba0324726a3d687c618aa4f163.png',
+    verified: true,
+    chains: {
+      [ChainId.POL]: {
+        address: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
+        decimals: 18,
+      },
+    },
+  },
+  // > POL migrated from MATIC
+  {
+    key: CoinKey.POL,
+    name: CoinKey.POL,
+    logoURI:
+      'https://static.debank.com/image/matic_token/logo_url/matic/6f5a6b6f0732a7a235131bd7804d357c.png',
+    verified: true,
+    chains: {
+      [ChainId.ETH]: {
+        address: '0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6',
+        decimals: 18,
+        name: 'Polygon Ecosystem Token',
+      },
+      [ChainId.POL]: {
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: 18,
+        name: 'Polygon Ecosystem Token',
       },
     },
   },

--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -164,20 +164,6 @@ export const basicCoins: BasicCoin[] = [
       },
     },
   },
-  // > WMATIC
-  {
-    key: 'WMATIC' as CoinKey,
-    name: CoinKey.POL,
-    logoURI:
-      'https://static.debank.com/image/matic_token/logo_url/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/f6e604ba0324726a3d687c618aa4f163.png',
-    verified: true,
-    chains: {
-      [ChainId.POL]: {
-        address: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
-        decimals: 18,
-      },
-    },
-  },
   // > POL migrated from MATIC
   {
     key: CoinKey.POL,
@@ -1676,11 +1662,11 @@ export const wrappedTokens: { [ChainId: string]: StaticToken } = {
   [ChainId.POL]: {
     // https://polygonscan.com/token/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270
     address: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
-    symbol: 'WMATIC',
+    symbol: 'WPOL',
     decimals: 18,
     chainId: ChainId.POL,
-    coinKey: 'WMATIC' as CoinKey,
-    name: 'WMATIC',
+    coinKey: CoinKey.WPOL,
+    name: 'WPOL',
     logoURI:
       'https://static.debank.com/image/matic_token/logo_url/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/f6e604ba0324726a3d687c618aa4f163.png',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,7 +590,7 @@ __metadata:
   dependencies:
     "@commitlint/cli": "npm:^19.3.0"
     "@commitlint/config-conventional": "npm:^19.2.2"
-    "@lifi/types": "npm:^15.3.1"
+    "@lifi/types": "npm:^15.4.0"
     "@solana/web3.js": "npm:^1.95.1"
     "@types/fs-extra": "npm:^11.0.4"
     "@typescript-eslint/eslint-plugin": "npm:^7.17.0"
@@ -611,10 +611,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lifi/types@npm:^15.3.1":
-  version: 15.3.1
-  resolution: "@lifi/types@npm:15.3.1"
-  checksum: 10/de1cc36961fe5613a06b7c08745a79bbe1725ff4d16d4072731b3807e950d7f4155846974101efd3b75dae3b59166444410bbdf8e9bced27af8cca65f21b2584
+"@lifi/types@npm:^15.4.0":
+  version: 15.4.0
+  resolution: "@lifi/types@npm:15.4.0"
+  checksum: 10/fd74e6360fbc05ab715646ebf6193f075b4d0af55c39329f9254c2c81c7cc39dd31f8a508743d3b69c09dd710aad6084f6c5af8413619fbcdb279748f2b0baeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-9658
- Change matic chain information
   - In terms of coins, I would like to keep Matic coins for other chains except matic chain, after the migration, matic may be still exchangable in some dex or place. Add Pol coins for all chains, including matic chain
   - Change wmatic token to wpol token symbol