### PR TITLE
fix: usdce aurora and add native usdc

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -707,7 +707,7 @@ export const basicCoins: BasicCoin[] = [
         decimals: 6,
       },
       [ChainId.AUR]: {
-        address: '0xB12BFcA5A55806AaF64E99521918A4bf0fC40802',
+        address: '0x368EBb46ACa6b8D0787C96B2b20bD3CC3F2c45F7',
         decimals: 6,
       },
       // https://evmexplorer.velas.com/token/0xe2C120f188eBd5389F71Cf4d9C16d05b62A58993
@@ -814,6 +814,12 @@ export const basicCoins: BasicCoin[] = [
       },
       [ChainId.KAI]: {
         address: '0xe2053bcf56d2030d2470fb454574237cf9ee3d4b',
+        decimals: 6,
+        name: 'Bridged USD Coin',
+        symbol: 'USDC.e',
+      },
+      [ChainId.AUR]: {
+        address: '0xB12BFcA5A55806AaF64E99521918A4bf0fC40802',
         decimals: 6,
         name: 'Bridged USD Coin',
         symbol: 'USDC.e',


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-9732

The problem could be token address,
address on UI is  https://explorer.aurora.dev/address/0xB12BFcA5A55806AaF64E99521918A4bf0fC40802
but stargate supported is  https://explorer.aurora.dev/token/0x368EBb46ACa6b8D0787C96B2b20bD3CC3F2c45F7

Aurora has already supported native USDC, and stargateV2 moved to this native token, rather than bridged USDC(USDC.e)