### PR TITLE
fix: rename SUI -> Sui

### DIFF
--- a/src/chains/supportedChains.mvm.ts
+++ b/src/chains/supportedChains.mvm.ts
@@ -5,7 +5,7 @@ export const supportedMVMChains: MVMChain[] = [
   {
     key: ChainKey.SUI,
     chainType: ChainType.MVM,
-    name: 'SUI',
+    name: 'Sui',
     coin: CoinKey.SUI,
     id: ChainId.SUI,
     mainnet: true,
@@ -15,9 +15,9 @@ export const supportedMVMChains: MVMChain[] = [
     metamask: {
       chainId: ChainId.SUI.toString(),
       blockExplorerUrls: ['https://www.suiscan.xyz/', 'https://suivision.xyz/'],
-      chainName: 'SUI',
+      chainName: 'Sui',
       nativeCurrency: {
-        name: 'SUI',
+        name: 'Sui',
         symbol: 'SUI',
         decimals: 9,
       },


### PR DESCRIPTION
Sui chain and token name aren't all capitalised. old casing was like "SUI"

https://suiscan.xyz/mainnet/coin/0x2::sui::SUI/txs