### PR TITLE
fix: update berachain metamask chain name

### DIFF
--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -1160,7 +1160,7 @@ export const supportedEVMChains: EVMChain[] = [
     metamask: {
       chainId: prefixChainId(80094),
       blockExplorerUrls: ['https://berascan.com/', 'https://beratrail.io/'],
-      chainName: 'Berachain',
+      chainName: 'Berachain Mainnet',
       nativeCurrency: {
         name: 'Bera',
         symbol: 'BERA',


### PR DESCRIPTION
Just follow the metamask information listed on https://berascan.com/
<img width="1116" alt="image" src="https://github.com/user-attachments/assets/58ae4074-d370-404d-9288-3ebfaa4d425e" />
