### PR TITLE
fix: wrong decimals for usdt on soneium

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -694,7 +694,7 @@ export const basicCoins: BasicCoin[] = [
       },
       [ChainId.SOE]: {
         address: '0x3A337a6adA9d885b6Ad95ec48F9b75f197b5AE35',
-        decimals: 18,
+        decimals: 6,
         name: 'Bridged USDT (Soneium)',
         symbol: 'USDT',
       },


### PR DESCRIPTION
Relates to [https://lifi.atlassian.net/browse/LF-12751](https://lifi.atlassian.net/browse/LF-12751)

Update USDT coin decimals on Soneium chain from **18** to **6**