### PR TITLE
fix(metis): use AddressZero as native

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -1934,7 +1934,7 @@ export const basicCoins: BasicCoin[] = [
     verified: true,
     chains: {
       [ChainId.MAM]: {
-        address: '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000',
+        address: '0x0000000000000000000000000000000000000000',
         decimals: 18,
       },
     },


### PR DESCRIPTION
We have to use AddressZero for native instead of the ERC20 representation. Otherwise all native -> X transactions are failing.