### PR TITLE
fix: Update Katana block explorer

### DIFF
--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -1563,7 +1563,7 @@ export const supportedEVMChains: EVMChain[] = [
 
     metamask: {
       chainId: prefixChainId(ChainId.KAT),
-      blockExplorerUrls: ['https://explorer.katana.network/'],
+      blockExplorerUrls: ['https://katanascan.com/'],
       chainName: 'Katana',
       nativeCurrency: {
         name: CoinKey.ETH,


### PR DESCRIPTION
We were using `https://explorer.katana.network/` , which doesn't seem to be working anymore. 
Changed it to `https://katanascan.com/`