### PR TITLE
feat: correct usdc address for celo

### DIFF
--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -896,7 +896,7 @@ export const basicCoins: BasicCoin[] = [
         decimals: 6,
       },
       [ChainId.CEL]: {
-        address: '0xef4229c8c3250c675f21bcefa42f58efbff6002a',
+        address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
         decimals: 6,
       },
       [ChainId.MOO]: {


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-14701


We list an old (https://celoscan.io/token/0xef4229c8c3250c675f21bcefa42f58efbff6002a) USDC coin in our types:
https://github.com/search?q=repo%3Alifinance%2Fdata-types%200xef4229c8c3250c675f21bcefa42f58efbff6002a&type=code The proper one is https://celoscan.io/token/0xcebA9300f2b948710d2653dD7B07f33A8B32118CAlso check for references in the backend