### PR TITLE
Chore: add explorer liveliness check and update values

### DIFF
--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -155,7 +155,7 @@ export const supportedEVMChains: EVMChain[] = [
     // https://docs.fantom.foundation/tutorials/set-up-metamask
     metamask: {
       chainId: prefixChainId(250),
-      blockExplorerUrls: ['https://ftmscan.com/'],
+      blockExplorerUrls: ['https://explorer.fantom.network/'],
       chainName: 'Fantom Opera',
       nativeCurrency: {
         name: 'FTM',
@@ -912,11 +912,7 @@ export const supportedEVMChains: EVMChain[] = [
         symbol: 'ETH',
         decimals: 18,
       },
-      rpcUrls: [
-        'https://rpc.mainnet.taiko.xyz',
-        'https://rpc.taiko.xyz',
-        'https://rpc.taiko.tools',
-      ],
+      rpcUrls: ['https://rpc.mainnet.taiko.xyz', 'https://rpc.taiko.xyz'],
     },
   },
 
@@ -986,7 +982,7 @@ export const supportedEVMChains: EVMChain[] = [
 
     metamask: {
       chainId: prefixChainId(8217),
-      blockExplorerUrls: ['https://kaiascan.io/', 'https://kaiascope.com/'],
+      blockExplorerUrls: ['https://kaiascan.io/'],
       chainName: 'Kaia Mainnet',
       nativeCurrency: {
         name: 'KAIA',
@@ -1560,10 +1556,7 @@ export const supportedEVMChains: EVMChain[] = [
 
     metamask: {
       chainId: prefixChainId(ChainId.KAT),
-      blockExplorerUrls: [
-        'https://katanascan.com/',
-        'https://explorer.katana.network/',
-      ],
+      blockExplorerUrls: ['https://katanascan.com/'],
       chainName: 'Katana',
       nativeCurrency: {
         name: CoinKey.ETH,

--- a/src/chains/supportedChains.utxo.ts
+++ b/src/chains/supportedChains.utxo.ts
@@ -16,7 +16,8 @@ export const supportedUXTOChains: UTXOChain[] = [
       chainId: ChainId.BTC.toString(),
       blockExplorerUrls: [
         'https://mempool.space/',
-        'https://blockchair.com/bitcoin/',
+        'https://blockstream.info/',
+        'https://www.blockchain.com/explorer/assets/btc',
       ],
       chainName: 'Bitcoin',
       nativeCurrency: {
@@ -42,7 +43,7 @@ export const supportedUXTOChains: UTXOChain[] = [
     faucetUrls: [],
     metamask: {
       chainId: ChainId.BCH.toString(),
-      blockExplorerUrls: ['https://blockchair.com/bitcoin-cash/'],
+      blockExplorerUrls: ['https://www.blockchain.com/explorer/assets/bch'],
       chainName: 'Bitcoin Cash',
       nativeCurrency: {
         name: 'BCH',
@@ -64,7 +65,7 @@ export const supportedUXTOChains: UTXOChain[] = [
     faucetUrls: [],
     metamask: {
       chainId: ChainId.LTC.toString(),
-      blockExplorerUrls: ['https://blockchair.com/litecoin/'],
+      blockExplorerUrls: ['https://litecoinspace.org/'],
       chainName: 'Litecoin',
       nativeCurrency: {
         name: 'LTC',
@@ -86,7 +87,7 @@ export const supportedUXTOChains: UTXOChain[] = [
     faucetUrls: [],
     metamask: {
       chainId: ChainId.DGE.toString(),
-      blockExplorerUrls: ['https://blockchair.com/dogecoin/'],
+      blockExplorerUrls: ['https://blockexplorer.one/dogecoin/mainnet/'],
       chainName: 'Dogecoin',
       nativeCurrency: {
         name: 'DODGE',

--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -2500,7 +2500,7 @@ export const basicCoins: BasicCoin[] = [
     key: CoinKey.BYUSD,
     name: CoinKey.BYUSD,
     logoURI:
-      'https://hub.berachain.com/_next/image/?url=https%3A%2F%2Fres.cloudinary.com%2Fduv0g402y%2Fimage%2Fupload%2Fv1738732576%2Ftokens%2Fy6wa21vehnappbe2cruf.png&w=3840&q=75&dpl=dpl_FBim27rRDfMcGJQxRsgz2AneXzpt',
+      'https://assets.coingecko.com/coins/images/67819/standard/byusd.png?1753942382',
     verified: true,
     chains: {
       [ChainId.BER]: {


### PR DESCRIPTION
2 commits:
- one to add a liveliness check on explorers
- another one to update some values (some explorers, RPCs and one asset).

Note: Fusion blockchain still need to be removed but will be done separately.