### PR TITLE
feat: Add USDC on HyperEVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [6.35.3-beta.0](https://github.com/lifinance/data-types/compare/v6.35.2...v6.35.3-beta.0) (2025-09-18)
-
 ### [6.35.2](https://github.com/lifinance/data-types/compare/v6.35.1...v6.35.2) (2025-09-08)
 
 ### [6.35.1](https://github.com/lifinance/data-types/compare/v6.35.0...v6.35.1) (2025-09-08)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.35.3-beta.0",
+  "version": "6.35.2",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",


### PR DESCRIPTION
- USDC has recently be deployed to HyperEVM.
- We need it for Mayan FastMCTP on HyperEVM.