### PR TITLE
fix: correct chain name Nibiru

### DIFF
--- a/src/chains/foundry.ts
+++ b/src/chains/foundry.ts
@@ -24,7 +24,7 @@ export const foundryChainNameMap: Record<ChainId, string> = {
   [ChainId.SUP]: 'superposition',
   [ChainId.INK]: 'ink',
   [ChainId.BOC]: 'bob',
-  [ChainId.NIB]: 'niburu',
+  [ChainId.NIB]: 'nibiru',
   [ChainId.KAT]: 'katana',
   [ChainId.BER]: 'berachain',
   [ChainId.VIC]: 'viction',


### PR DESCRIPTION
Fixes a typo in the network name for `ChainId.NIB` from `niburu` to `nibiru`.

Without this fix, any operations with the Nibiru network via Foundry will end in an error, as the tool will not be able to find the configuration for the incorrect name.