### PR TITLE
feat: add new chain Lighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.79.0-alpha.0",
+  "version": "6.78.1",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.78.0-alpha.0"
+    "@lifi/types": "17.78.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.76.0"
+    "@lifi/types": "17.78.0-alpha.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.78.1",
+  "version": "6.79.0-alpha.0",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.78.0-alpha.0
-        version: 17.78.0-alpha.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: 17.78.0
+        version: 17.78.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.78.0-alpha.0':
-    resolution: {integrity: sha512-VMrNKODJXiSQH2Ign8WQyQmjmjogMj1BFou4m7fLuq6EexnN8rH+QjuCP+T6Qhd3s+K8YRJe0doemawmy+2YMw==}
+  '@lifi/types@17.78.0':
+    resolution: {integrity: sha512-ifuX7MAmoGp5dZN+6cotiQ/yhNAierkQU+ElwJ4O4Yqaaba4czl02p0JKpv6g9xxKWkMS4VZjOnmwHWgwAX6CA==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.78.0-alpha.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@lifi/types@17.78.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       viem: 2.46.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.76.0
-        version: 17.76.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: 17.78.0-alpha.0
+        version: 17.78.0-alpha.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.76.0':
-    resolution: {integrity: sha512-lu1g9Vw650zqY5KYFSQztgrm1LzLgOIJcABxFzAN+S/n0ujL+MIYn0pjI111zUupBzZ5XKLjGvHQ6uT2EjkgKQ==}
+  '@lifi/types@17.78.0-alpha.0':
+    resolution: {integrity: sha512-VMrNKODJXiSQH2Ign8WQyQmjmjogMj1BFou4m7fLuq6EexnN8rH+QjuCP+T6Qhd3s+K8YRJe0doemawmy+2YMw==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.76.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@lifi/types@17.78.0-alpha.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       viem: 2.46.3(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:

--- a/src/chains/foundry.ts
+++ b/src/chains/foundry.ts
@@ -92,6 +92,7 @@ export const foundryChainNameMap: Record<ChainId, string> = {
   [ChainId.TRN]: 'tron',
   [ChainId.SUI]: 'sui',
   [ChainId.HPL]: 'hyperliquid',
+  [ChainId.LTR]: 'lighter',
   [ChainId.OAS]: 'oasis',
   [ChainId.SOL]: 'solana',
   [ChainId.FOG]: 'fogo',

--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -1666,6 +1666,29 @@ export const supportedEVMChains: EVMChain[] = [
       rpcUrls: [],
     },
   },
+  {
+    key: ChainKey.LTR,
+    chainType: ChainType.EVM,
+    name: 'Lighter',
+    coin: CoinKey.USDC,
+    id: ChainId.LTR,
+    mainnet: true,
+    multicallAddress: multicallAddresses[ChainId.LTR],
+    logoURI:
+      'https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/lighter.svg',
+    relayerSupported: false,
+    metamask: {
+      chainId: prefixChainId(ChainId.ETH),
+      blockExplorerUrls: ['https://lighter.exchange/explorer/'],
+      chainName: 'Lighter',
+      nativeCurrency: {
+        name: CoinKey.USDC,
+        symbol: CoinKey.USDC,
+        decimals: 6,
+      },
+      rpcUrls: [],
+    },
+  },
 
   {
     key: ChainKey.SOP,

--- a/src/chains/supportedChains.unit.spec.ts
+++ b/src/chains/supportedChains.unit.spec.ts
@@ -33,6 +33,7 @@ test('native and wrapped token defined for all chains', () => {
     ChainId.ZEC,
     ChainId.SUI,
     ChainId.HPL,
+    ChainId.LTR,
   ]
   for (const chain of supportedChains) {
     if (ignoredChainsForNativeToken.includes(chain.id)) {
@@ -88,7 +89,7 @@ describe('findTokenByChainIdAndAddress', () => {
 })
 
 describe('validate chains', () => {
-  const ignoredChains = [ChainId.HPL]
+  const ignoredChains = [ChainId.HPL, ChainId.LTR]
   supportedEVMChains.forEach((chain) => {
     it(`validate chain ${chain.name}`, () => {
       if (ignoredChains.includes(chain.id)) {

--- a/src/coins/coins.ts
+++ b/src/coins/coins.ts
@@ -207,6 +207,11 @@ export const basicCoins: BasicCoin[] = [
         address: '0x0000000000000000000000000000000000000000',
         decimals: 18,
       },
+      [ChainId.LTR]: {
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: 18,
+        name: 'Ether (Spot)',
+      },
     },
   },
   // > MATIC
@@ -1130,6 +1135,11 @@ export const basicCoins: BasicCoin[] = [
         address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
         decimals: 6,
         name: 'USD Coin (Perps)',
+      },
+      [ChainId.LTR]: {
+        address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        decimals: 6,
+        name: 'USD Coin (Perp)',
       },
       [ChainId.SOP]: {
         address: '0x9Aa0F72392B5784Ad86c6f3E899bCc053D00Db4F',
@@ -4365,6 +4375,16 @@ export const wrappedTokens: { [ChainId: string]: StaticToken } = {
     symbol: CoinKey.USDC,
     coinKey: CoinKey.USDC,
     chainId: ChainId.HPL,
+    decimals: 6,
+    logoURI:
+      'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
+  },
+  [ChainId.LTR]: {
+    name: 'USD Coin (Perp)',
+    address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    symbol: CoinKey.USDC,
+    coinKey: CoinKey.USDC,
+    chainId: ChainId.LTR,
     decimals: 6,
     logoURI:
       'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',

--- a/src/multicall.ts
+++ b/src/multicall.ts
@@ -80,6 +80,7 @@ export const multicallAddresses: { [ChainId: number]: string } = {
   [ChainId.MEG]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.BOT]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.HPL]: '0xcA11bde05977b3631167028862bE2a173976CA11', // HyperLiquid is not EVM compatible, but we support it via our EVM-compatible API wrapper.
+  [ChainId.LTR]: '0xcA11bde05977b3631167028862bE2a173976CA11', // Lighter is not EVM compatible, but we support it via our EVM-compatible API wrapper.
   [ChainId.TLO]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.JOV]: '0xcA11bde05977b3631167028862bE2a173976CA11',
   [ChainId.MOP]: '0xA403025927d715a41Ccbad5EAeBf2979055e639e',


### PR DESCRIPTION
Adds Lighter (ChainId.LTR = 3586256) — custom non-EVM venue exposed as EVM, deposit-only via Relay. Native USDC; ETH spot also supported.

Depends on https://github.com/lifinance/types/pull/521 — using @lifi/types@17.78.0-alpha.0.