### PR TITLE
chore: update gas decimals and tempo PathUSD symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.82.0"
+    "@lifi/types": "17.82.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.82.0
-        version: 17.82.0
+        specifier: 17.82.1
+        version: 17.82.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.82.0':
-    resolution: {integrity: sha512-i7mZ9dHkDtpzYBEpyyGQlN0R3AG7kbPgI0dg8uzWYLuec6ud8UfeVg/oECzCY9izCAtrfWwq/QeoEaWdn9VeYw==}
+  '@lifi/types@17.82.1':
+    resolution: {integrity: sha512-n1FDyQtREj8RO/6XTeC1B2fq39t3CUlm7b+TeiMKQ6pLRpovwAZFhhv7dZIuAqr9FJvXc3cKVciyrR3L5IthmQ==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.82.0': {}
+  '@lifi/types@17.82.1': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:

--- a/src/chains/supportedChains.evm.ts
+++ b/src/chains/supportedChains.evm.ts
@@ -1836,7 +1836,7 @@ export const supportedEVMChains: EVMChain[] = [
       nativeCurrency: {
         name: 'USDT0',
         symbol: CoinKey.USDT0,
-        decimals: 6,
+        decimals: 18,
       },
       rpcUrls: ['https://rpc.stable.xyz'],
     },
@@ -1960,8 +1960,8 @@ export const supportedEVMChains: EVMChain[] = [
       chainName: 'Tempo',
       nativeCurrency: {
         name: 'PathUSD',
-        symbol: 'PathUSD',
-        decimals: 6,
+        symbol: 'PUSD',
+        decimals: 18,
       },
       rpcUrls: ['https://rpc.tempo.xyz'],
     },
@@ -2064,7 +2064,7 @@ export const supportedEVMChains: EVMChain[] = [
       nativeCurrency: {
         name: 'USDC',
         symbol: 'USDC',
-        decimals: 6,
+        decimals: 18,
       },
       rpcUrls: ['https://rpc.testnet.arc.network/'],
     },


### PR DESCRIPTION
Linear ticket: https://linear.app/lifi-linear/issue/EXBE-340/update-gas-decimals-and-tempo-pathusd-symbol

Important: release a bit before a new deployment of the backend app.