### PR TITLE
feat: bump @lifi/types to 17.87.0-beta.1 (amountFlexible route option)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.83.0",
+  "version": "6.84.0-beta.0",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.86.0"
+    "@lifi/types": "17.87.0-beta.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.86.0
-        version: 17.86.0
+        specifier: 17.87.0-beta.1
+        version: 17.87.0-beta.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.86.0':
-    resolution: {integrity: sha512-VkEK2c7pL2P49cVZfSW76pbMJNCrWC4ge2FmyexyZW71XA56bv+AAj9zL8zeEQVQUnMnekQVC1EHVBlx5uBwdg==}
+  '@lifi/types@17.87.0-beta.1':
+    resolution: {integrity: sha512-DPxU4Z0XF1ZPAVxJ/16yGc9+79ZWz96Kc3IMc3B6KEeUb3bFVQdb2hPftUYbKggZ+iHBcm/A1o4HyenzCb/pnw==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.86.0': {}
+  '@lifi/types@17.87.0-beta.1': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:


### PR DESCRIPTION
Pins `@lifi/types` to `17.87.0-beta.1` (adds `RouteOptions.amountFlexible` — see lifinance/types#552), so the backend can consume both packages without a duplicated `@lifi/types` copy, per the beta-release process.

Beta released from this branch. Not to be merged until lifinance/types#552 gets its official release; then this bumps to the official version and merges.