### PR TITLE
chore: bump @lifi/types to 17.87.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.83.0",
+  "version": "6.84.0-beta.0",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.84.0-beta.0",
+  "version": "6.84.0-beta.1",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.87.0-beta.1"
+    "@lifi/types": "17.87.0-beta.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.86.0"
+    "@lifi/types": "17.87.0-beta.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.86.0
-        version: 17.86.0
+        specifier: 17.87.0-beta.1
+        version: 17.87.0-beta.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.86.0':
-    resolution: {integrity: sha512-VkEK2c7pL2P49cVZfSW76pbMJNCrWC4ge2FmyexyZW71XA56bv+AAj9zL8zeEQVQUnMnekQVC1EHVBlx5uBwdg==}
+  '@lifi/types@17.87.0-beta.1':
+    resolution: {integrity: sha512-DPxU4Z0XF1ZPAVxJ/16yGc9+79ZWz96Kc3IMc3B6KEeUb3bFVQdb2hPftUYbKggZ+iHBcm/A1o4HyenzCb/pnw==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.86.0': {}
+  '@lifi/types@17.87.0-beta.1': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.87.0-beta.1
-        version: 17.87.0-beta.1
+        specifier: 17.87.0-beta.2
+        version: 17.87.0-beta.2
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.87.0-beta.1':
-    resolution: {integrity: sha512-DPxU4Z0XF1ZPAVxJ/16yGc9+79ZWz96Kc3IMc3B6KEeUb3bFVQdb2hPftUYbKggZ+iHBcm/A1o4HyenzCb/pnw==}
+  '@lifi/types@17.87.0-beta.2':
+    resolution: {integrity: sha512-BORpLCN9taGj9dFL8Stf4DhC0yHXHLeeVcguIIHaUZeB9wJUkTnOvJ6A2GV+5SSwlF03CtxY3Iae8HR33q1mUw==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.87.0-beta.1': {}
+  '@lifi/types@17.87.0-beta.2': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:


### PR DESCRIPTION
## What this does
Bumps `@lifi/types` to `17.87.0-beta.2`, which adds the two Smart Deposits destination-action params to `QuoteRequest` (types#553). Required so backend consumers of both packages don't hit type conflicts between the pins.

## Heads-up for reviewers
- **Stacked on #263** (the amount-flexible beta bump) — merge #263 first; this PR then shows only the one commit.
- Pairs with [types#553](https://github.com/lifinance/types/pull/553) and [lifi-backend#8687](https://github.com/lifinance/lifi-backend/pull/8687).
