### PR TITLE
chore: bump @lifi/types to 17.88.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.83.0",
+  "version": "6.85.0-beta.0",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.86.0"
+    "@lifi/types": "17.88.0-beta.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.86.0
-        version: 17.86.0
+        specifier: 17.88.0-beta.0
+        version: 17.88.0-beta.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.86.0':
-    resolution: {integrity: sha512-VkEK2c7pL2P49cVZfSW76pbMJNCrWC4ge2FmyexyZW71XA56bv+AAj9zL8zeEQVQUnMnekQVC1EHVBlx5uBwdg==}
+  '@lifi/types@17.88.0-beta.0':
+    resolution: {integrity: sha512-p3burMmx8SW42qntGEawZjhnWyNu299/zs4FfInaoIcX7y5C5hzRCIOhLw2IuS8ozMHsb3UsRbQYX4ZHe9xGeQ==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.86.0': {}
+  '@lifi/types@17.88.0-beta.0': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:


### PR DESCRIPTION
Re-pins `@lifi/types` to `17.88.0-beta.0` (the amountFlexible beta, lifinance/types#555) and releases **`@lifi/data-types@6.85.0-beta.0`**.

Supersedes #263: the previous ladder's 17.87.0/6.84.0 version lines were burned by an unrelated official `@lifi/types` 17.87.0 release on 2026-07-29 (its betas now semver-precede `latest`, and 6.84.0-beta.0/.1 are already published, so the line cannot continue). This rung restarts the ladder at 6.85.0.

⚠️ Rung 1 of three (one per consuming lifi-backend PR: #8662 → #8687 → #8705) — do not merge until the official release step.