### PR TITLE
chore: bump @lifi/types to 17.88.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/data-types",
-  "version": "6.85.0-beta.0",
+  "version": "6.85.0-beta.1",
   "description": "Data types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "17.88.0-beta.0"
+    "@lifi/types": "17.88.0-beta.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.88.0-beta.0
-        version: 17.88.0-beta.0
+        specifier: 17.88.0-beta.1
+        version: 17.88.0-beta.1
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@17.88.0-beta.0':
-    resolution: {integrity: sha512-p3burMmx8SW42qntGEawZjhnWyNu299/zs4FfInaoIcX7y5C5hzRCIOhLw2IuS8ozMHsb3UsRbQYX4ZHe9xGeQ==}
+  '@lifi/types@17.88.0-beta.1':
+    resolution: {integrity: sha512-31+loOlbcalU4foSbdZd2tFS+BdiQhvWJPHOHXZ6h3eso8faw9YvseO2MGCu1YRAW3UZr/KOK3qlWuJw4jLS6w==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@17.88.0-beta.0': {}
+  '@lifi/types@17.88.0-beta.1': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:


### PR DESCRIPTION
Re-pins `@lifi/types` to `17.88.0-beta.1` (the quote destinationAction params, lifinance/types#556) and releases **`@lifi/data-types@6.85.0-beta.1`**.

Supersedes #264 (see #265 for the version-line burn context). Rung 2 of three, consumed by lifi-backend #8687.

⚠️ Stacked on #265 — do not merge until the official release step; merge order follows the types stack.