### PR TITLE
chore(deps): bump @lifi/types to 18.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@lifi/types": "18.0.0"
+    "@lifi/types": "18.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 18.0.0
-        version: 18.0.0
+        specifier: 18.2.0
+        version: 18.2.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -440,8 +440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lifi/types@18.0.0':
-    resolution: {integrity: sha512-uzC5XAkHdV/iMQdIyGZdijfLo/ED41NH3QVDY47WZgQx2vTyHmbiqcMxx3pzli/oGV1SSug0aozZtfIT7iiB9g==}
+  '@lifi/types@18.2.0':
+    resolution: {integrity: sha512-ap0p93xeLAMAnSQfGaeV6Gb2SLcgmyUOXav9w7fBHIcDK87Oio+On7WF4syknpwBd/JfbTV/gpH+Yfs2biQJcA==}
 
   '@mysten/bcs@1.9.2':
     resolution: {integrity: sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==}
@@ -3141,7 +3141,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lifi/types@18.0.0': {}
+  '@lifi/types@18.2.0': {}
 
   '@mysten/bcs@1.9.2':
     dependencies:


### PR DESCRIPTION
Bumps the exact `@lifi/types` pin 18.0.0 → 18.2.0 (current npm `latest`).

7.0.0 froze the pin at 18.0.0, which predates the `destinationAction` halves on `RouteOptions`/`LiFiStep` (shipped in 18.2.0 via lifinance/types#564) — consumers resolving types through `@lifi/data-types` currently miss them.

One-line dependency bump + lockfile only; no version change (release automation cuts it on main).

Verification: `pnpm build` green; `pnpm test` = 894 passed / 14 failed — the 14 are network-dependent `*.int.spec` failures reproduced **byte-identically on unbumped `origin/main`** (same files, same counts), i.e. pre-existing and unrelated to this bump.